### PR TITLE
Pass in tool-specific file names in `getLoggingPaths()` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # node-clinic-common
+
 Common functionality shared throughout node-clinic
+
+## `getLoggingPaths(toolName, toolSpecificFiles=[])`
+
+Create a function that builds paths for tool log information. The returned function returns an object mapping virtual path names to actual path names, such as:
+
+```js
+{
+  '/systeminfo': '{pid}.clinic-{toolName}/{pid}.clinic-{toolName}-systeminfo'
+}
+```
+
+Arguments:
+  - `toolName` - name of the clinic tool.
+  - `toolSpecificFiles` - array of file names to generate, on top of the defaults (`/`, `/systeminfo`).
+    If `toolName` is 'doctor', this defaults to `['/traceevent', '/processstat']`.
+    If `toolName` is 'bubbleprof', this defaults to `['/traceevent', '/stacktrace']`.
+
+## License
+
+[GPL 3.0](LICENSE)

--- a/lib/get-logging-paths.js
+++ b/lib/get-logging-paths.js
@@ -2,8 +2,18 @@
 
 const path = require('path')
 
-function wrapper (name) {
-  return function getLoggingPaths(options) {
+function wrapper (toolName, toolSpecificFiles) {
+  if (!toolSpecificFiles) {
+    if (toolName === 'doctor') {
+      toolSpecificFiles = ['/traceevent', '/processstat']
+    } else if (toolName === 'bubbleprof') {
+      toolSpecificFiles = ['/traceevent', '/stacktrace']
+    } else {
+      toolSpecificFiles = []
+    }
+  }
+
+  return function getLoggingPaths (options) {
     let dirpath, basename
     if (options.hasOwnProperty('identifier') && options.identifier) {
       if (options.hasOwnProperty('path') && options.path) {
@@ -14,32 +24,25 @@ function wrapper (name) {
       basename = options.identifier.toString()
     } else if (options.hasOwnProperty('path') && options.path) {
       dirpath = path.dirname(options.path)
-      basename = path.basename(options.path, `.clinic-${name}`)
+      basename = path.basename(options.path, `.clinic-${toolName}`)
     } else {
       throw new Error('missing either identifier or path value')
     }
 
-    const dirname = `${basename}.clinic-${name}`
-    const traceEventFilename = `${basename}.clinic-${name}-traceevent`
-    const systemInfoFilename = `${basename}.clinic-${name}-systeminfo`
+    const dirname = `${basename}.clinic-${toolName}`
+    const systemInfoFilename = `${basename}.clinic-${toolName}-systeminfo`
 
-    let extra
-    if (name === 'doctor') {
-      const filename = `${basename}.clinic-${name}-processstat`
-      extra = { '/processstat': path.join(dirpath, dirname, filename) }
-    } else if (name === 'bubbleprof') {
-      const filename = `${basename}.clinic-${name}-stacktrace`
-      extra = { '/stacktrace': path.join(dirpath, dirname, filename) }
-    } else {
-      extra = {}
-    }
-
-    return {
+    const loggingPaths = {
       '/': path.join(dirpath, dirname),
-      '/systeminfo': path.join(dirpath, dirname, systemInfoFilename),
-      '/traceevent': path.join(dirpath, dirname, traceEventFilename),
-      ...extra
+      '/systeminfo': path.join(dirpath, dirname, systemInfoFilename)
     }
+    toolSpecificFiles.forEach((name) => {
+      const cleanName = name.replace(/^\/|\/$/g, '')
+      const filename = `${basename}.clinic-${toolName}-${cleanName}`
+      loggingPaths[name] = path.join(dirpath, dirname, filename)
+    })
+
+    return loggingPaths
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "echo 'No tests so far. Please add some.'",
+    "test": "npm run lint && tap test/*.test.js",
     "lint": "standard --fix"
   },
   "repository": {
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/nearform/node-clinic-common#readme",
   "devDependencies": {
-    "standard": "^12.0.1"
+    "standard": "^12.0.1",
+    "tap": "^12.1.0"
   }
 }

--- a/test/get-logging-paths.test.js
+++ b/test/get-logging-paths.test.js
@@ -24,6 +24,30 @@ test('logging path - path', function (t) {
   t.end()
 })
 
+test('Collect - logging path - path and identifier', function (t) {
+  const paths = getLoggingPaths('doctor')({ path: './foo', identifier: 1062 })
+
+  t.strictDeepEqual(paths, {
+    '/': path.join('foo', '1062.clinic-doctor'),
+    '/traceevent': path.join('foo', '1062.clinic-doctor', '1062.clinic-doctor-traceevent'),
+    '/systeminfo': path.join('foo', '1062.clinic-doctor', '1062.clinic-doctor-systeminfo'),
+    '/processstat': path.join('foo', '1062.clinic-doctor', '1062.clinic-doctor-processstat')
+  })
+  t.end()
+})
+
+test('Collect - logging path - null path and identifier', function (t) {
+  const paths = getLoggingPaths('doctor')({ path: null, identifier: 1062 })
+
+  t.strictDeepEqual(paths, {
+    '/': path.join('', '1062.clinic-doctor'),
+    '/traceevent': path.join('', '1062.clinic-doctor', '1062.clinic-doctor-traceevent'),
+    '/systeminfo': path.join('', '1062.clinic-doctor', '1062.clinic-doctor-systeminfo'),
+    '/processstat': path.join('', '1062.clinic-doctor', '1062.clinic-doctor-processstat')
+  })
+  t.end()
+})
+
 test('logging path - supports 0x path templates', function (t) {
   const paths = getLoggingPaths('flame')({ identifier: '{pid}' })
   t.strictDeepEqual(paths, {
@@ -64,5 +88,29 @@ test('logging path - default paths for bubbleprof', function (t) {
     '/traceevent': path.normalize('2261.clinic-bubbleprof/2261.clinic-bubbleprof-traceevent'),
     '/stacktrace': path.normalize('2261.clinic-bubbleprof/2261.clinic-bubbleprof-stacktrace')
   })
+  t.end()
+})
+
+test('logging paths - null values', function (t) {
+  t.throws(
+    () => getLoggingPaths('toolname')({ identifier: null }),
+    new Error('missing either identifier or path value')
+  )
+  t.throws(
+    () => getLoggingPaths('toolname')({ path: null }),
+    new Error('missing either identifier or path value')
+  )
+  t.throws(
+    () => getLoggingPaths('toolname')({ path: null, identifier: null }),
+    new Error('missing either identifier or path value')
+  )
+  t.end()
+})
+
+test('logging paths - bad type', function (t) {
+  t.throws(
+    () => getLoggingPaths('toolname')({}),
+    new Error('missing either identifier or path value')
+  )
   t.end()
 })

--- a/test/get-logging-paths.test.js
+++ b/test/get-logging-paths.test.js
@@ -1,0 +1,68 @@
+const test = require('tap').test
+const path = require('path')
+const getLoggingPaths = require('../lib/get-logging-paths.js')
+
+const flameFiles = ['/samples', '/inlinedfunctions', '/0x-data/']
+
+test('logging path - identifier', function (t) {
+  const paths = getLoggingPaths('toolname')({ identifier: 1062 })
+
+  t.strictDeepEqual(paths, {
+    '/': '1062.clinic-toolname',
+    '/systeminfo': path.normalize('1062.clinic-toolname/1062.clinic-toolname-systeminfo')
+  })
+  t.end()
+})
+
+test('logging path - path', function (t) {
+  const paths = getLoggingPaths('toolname')({ path: path.normalize('/root/1062.clinic-toolname') })
+
+  t.strictDeepEqual(paths, {
+    '/': path.normalize('/root/1062.clinic-toolname'),
+    '/systeminfo': path.normalize('/root/1062.clinic-toolname/1062.clinic-toolname-systeminfo')
+  })
+  t.end()
+})
+
+test('logging path - supports 0x path templates', function (t) {
+  const paths = getLoggingPaths('flame')({ identifier: '{pid}' })
+  t.strictDeepEqual(paths, {
+    '/': path.normalize('{pid}.clinic-flame'),
+    '/systeminfo': path.normalize('{pid}.clinic-flame/{pid}.clinic-flame-systeminfo')
+  })
+  t.end()
+})
+
+test('logging path - tool-specific files', function (t) {
+  const paths = getLoggingPaths('flame', flameFiles)({ identifier: '2261' })
+  t.strictDeepEqual(paths, {
+    '/': path.normalize('2261.clinic-flame'),
+    '/systeminfo': path.normalize('2261.clinic-flame/2261.clinic-flame-systeminfo'),
+    '/samples': path.normalize('2261.clinic-flame/2261.clinic-flame-samples'),
+    '/inlinedfunctions': path.normalize('2261.clinic-flame/2261.clinic-flame-inlinedfunctions'),
+    '/0x-data/': path.normalize('2261.clinic-flame/2261.clinic-flame-0x-data')
+  })
+  t.end()
+})
+
+test('logging path - default paths for doctor', function (t) {
+  const paths = getLoggingPaths('doctor')({ identifier: '2261' })
+  t.strictDeepEqual(paths, {
+    '/': path.normalize('2261.clinic-doctor'),
+    '/systeminfo': path.normalize('2261.clinic-doctor/2261.clinic-doctor-systeminfo'),
+    '/traceevent': path.normalize('2261.clinic-doctor/2261.clinic-doctor-traceevent'),
+    '/processstat': path.normalize('2261.clinic-doctor/2261.clinic-doctor-processstat')
+  })
+  t.end()
+})
+
+test('logging path - default paths for bubbleprof', function (t) {
+  const paths = getLoggingPaths('bubbleprof')({ identifier: '2261' })
+  t.strictDeepEqual(paths, {
+    '/': path.normalize('2261.clinic-bubbleprof'),
+    '/systeminfo': path.normalize('2261.clinic-bubbleprof/2261.clinic-bubbleprof-systeminfo'),
+    '/traceevent': path.normalize('2261.clinic-bubbleprof/2261.clinic-bubbleprof-traceevent'),
+    '/stacktrace': path.normalize('2261.clinic-bubbleprof/2261.clinic-bubbleprof-stacktrace')
+  })
+  t.end()
+})


### PR DESCRIPTION
This patch allows passing in a list of file names that a tool needs to
the getLoggingPaths factory function. This way `getLoggingPaths` doesn't
need to know about the file paths needed by all the tools, and a change
to the paths needed by a tool doesn't have to be merged in clinic-common.

It also adds a test, ported from Flame and Doctor.

For backwards compatibility, the tool-specific file name list is still
prepopulated for 'doctor' and 'bubbleprof'. Flame will pass in its own
custom list and at some point we could update doctor and bubbleprof to
do the same.