### PR TITLE
[wip] exporting `loading-spinner`

### DIFF
--- a/spinner/index.js
+++ b/spinner/index.js
@@ -1,0 +1,11 @@
+if (window) {
+  window.addEventListener('load', e => document.body.classList.add('content-ready'))
+}
+
+module.exports = {
+  show: (msg = 'Loading file') => {
+    document.documentElement.style.setProperty('--loading-message', `"${msg}"`)
+    document.body.classList.remove('content-ready')
+  },
+  hide: () => { document.body.classList.add('content-ready') }
+}

--- a/spinner/style.css
+++ b/spinner/style.css
@@ -1,0 +1,59 @@
+html {
+  --loading-message: "Loading file";
+}
+
+body:not(.content-ready):before,
+body:not(.content-ready):after {
+  width: 124px;
+  height: 120px;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin-top: -60px;
+  margin-left: -60px;
+  z-index: 9;
+}
+
+body:not(.content-ready) {
+  position: relative;
+  z-index: 3;
+}
+
+body:not(.content-ready):before{
+  animation: loading 1.6s infinite linear;
+  border-bottom: 4px solid var(--flame-orange);
+  border-left: 1px solid var(--primary-grey);
+  border-radius: 50%;
+  border-right: 1px solid var(--primary-grey);
+  border-top: 4px solid var(--flame-orange);
+  content: "";
+  display: block;
+  transform: rotate(0deg);
+}
+
+body:not(.content-ready):after{
+  align-items: center;
+  color: var(--max-contrast);
+  content: var(--loading-message);
+  display: flex;
+  font-size: 12px;
+  font-weight: bold;
+  height: auto;
+  justify-content: center;
+  line-height: 1;
+  margin-top: 0;
+  position: absolute;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+@keyframes loading {
+  100% {
+    -webkit-transform: rotate(359deg);
+    -moz-transform: rotate(359deg);
+    -ms-transform: rotate(359deg);
+    -o-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+  
+}


### PR DESCRIPTION
This PR exports the 'loading-spinner' animation.
To add it to your app please import `@nearform/clinic-common/spinner` in your `main.js` and add the style.css file to your `style.css`

Example:
in main.js
```js
require('@nearform/clinic-common/spinner')
```

in style.css
```css
@import "@nearform/clinic-common/spinner/style.css";
```

This will display the loading spinner while the page gets loaded.
If you need to show the spinner later on, maybe while the app is busy doing some calculation, you can programmatically switch the spinner on and off as shown in the following example:

```js
const spinner = require('@nearform/clinic-common/spinner')
...
spinner.show('Melting the North pole...')
// when finished
spinner.hide()

```
