### PR TITLE
Brand fonts

### DIFF
--- a/behaviours/font-loader.js
+++ b/behaviours/font-loader.js
@@ -11,14 +11,15 @@ const allFonts = [
   'Space Mono:n7'
 ]
 
-const init = ({
-  onLoad,
-  onTimeout,
-  onLoadAfterTimeout,
-  timeout = 2000,
-  criticalFonts = allFonts,
-  ...opts
-} = {}) => {
+const init = (opts = {}) => {
+  const {
+    onLoad,
+    onTimeout,
+    onLoadAfterTimeout,
+    timeout = 2000,
+    criticalFonts = allFonts
+  } = opts
+
   // Flag loaded state
   let isLoading = true
   // Keep track of loaded fonts
@@ -74,16 +75,17 @@ const init = ({
   // Noop
   const destroy = () => null
 
-  // Kick things off
-  WebFont.load({
+  const webFontOpts = Object.assign({
     custom: {
       families: allFonts,
       urls: [styleSheetUrl]
     },
     active,
-    fontactive,
-    ...opts
-  })
+    fontactive
+  }, opts)
+
+  // Kick things off
+  WebFont.load(webFontOpts)
 
   return {
     destroy

--- a/behaviours/font-loader.js
+++ b/behaviours/font-loader.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const WebFont = require('webfontloader')
+
+const init = ({ onLoad } = {}) => {
+  const timeoutId = setTimeout(() => active(), 2000)
+
+  const active = () => {
+    clearTimeout(timeoutId)
+
+    if (onLoad) {
+      onLoad()
+    }
+  }
+
+  const destroy = () => null
+
+  WebFont.load({
+    custom: {
+      families: ['Archia:n4,n7', 'Campton:n7', 'Space Mono:n4,n7'],
+      urls: ['https://adoring-einstein-015923.netlify.com/assets/css/fonts.css']
+    },
+    active
+  })
+
+  return {
+    destroy
+  }
+}
+
+module.exports = init

--- a/behaviours/font-loader.js
+++ b/behaviours/font-loader.js
@@ -2,14 +2,14 @@
 
 const WebFont = require('webfontloader')
 
-const init = ({ onLoad } = {}) => {
-  const timeoutId = setTimeout(() => active(), 2000)
+const init = ({ onLoad, ...opts } = {}) => {
+  const timeoutId = setTimeout(() => active('Timeout'), 2000)
 
-  const active = () => {
+  const active = err => {
     clearTimeout(timeoutId)
 
     if (onLoad) {
-      onLoad()
+      onLoad(err)
     }
   }
 
@@ -20,7 +20,8 @@ const init = ({ onLoad } = {}) => {
       families: ['Archia:n4,n7', 'Campton:n7', 'Space Mono:n4,n7'],
       urls: ['https://adoring-einstein-015923.netlify.com/assets/css/fonts.css']
     },
-    active
+    active,
+    ...opts
   })
 
   return {

--- a/behaviours/font-loader.js
+++ b/behaviours/font-loader.js
@@ -2,7 +2,7 @@
 
 const WebFont = require('webfontloader')
 
-const styleSheetUrl = 'https://adoring-einstein-015923.netlify.com/assets/css/fonts.css'
+const styleSheetUrl = 'https://clinicjs.org/assets/css/fonts.css'
 const allFonts = [
   'Archia:n4',
   'Archia:n7',

--- a/behaviours/font-loader.js
+++ b/behaviours/font-loader.js
@@ -2,25 +2,86 @@
 
 const WebFont = require('webfontloader')
 
-const init = ({ onLoad, ...opts } = {}) => {
-  const timeoutId = setTimeout(() => active('Timeout'), 2000)
+const styleSheetUrl = 'https://adoring-einstein-015923.netlify.com/assets/css/fonts.css'
+const allFonts = [
+  'Archia:n4',
+  'Archia:n7',
+  'Campton:n7',
+  'Space Mono:n4',
+  'Space Mono:n7'
+]
 
-  const active = err => {
-    clearTimeout(timeoutId)
+const init = ({
+  onLoad,
+  onTimeout,
+  onLoadAfterTimeout,
+  timeout = 2000,
+  criticalFonts = allFonts,
+  ...opts
+} = {}) => {
+  // Flag loaded state
+  let isLoading = true
+  // Keep track of loaded fonts
+  const loadedFonts = []
 
-    if (onLoad) {
-      onLoad(err)
+  // Ensure timeout is triggered if all fonts fail to load
+  const timeoutId = setTimeout(() => {
+    isLoading = false
+
+    if (onTimeout) {
+      onTimeout()
+    }
+
+    maybeLoadAfterTimeout()
+  }, timeout)
+
+  // Check loaded fonts array against given critical fonts
+  const maybeLoadAfterTimeout = () => {
+    // If loaded already, exit
+    if (isLoading) {
+      return
+    }
+
+    // Create array of difference between loaded fonts and critical fonts
+    const loadedCriticalFonts = loadedFonts.filter(
+      item => criticalFonts.indexOf(item) > -1
+    )
+
+    // Call onLoadAfterTimeout if all critical fonts have loaded
+    if (criticalFonts.length === loadedCriticalFonts.length && onLoadAfterTimeout) {
+      isLoading = false
+
+      onLoadAfterTimeout()
     }
   }
 
+  // On all font load
+  const active = () => {
+    isLoading = false
+    clearTimeout(timeoutId)
+
+    if (onLoad) {
+      onLoad()
+    }
+  }
+
+  // On individual font load
+  const fontactive = (font, variant) => {
+    loadedFonts.push(`${font}:${variant}`)
+    maybeLoadAfterTimeout()
+  }
+
+  // Noop
   const destroy = () => null
 
+  // Kick things off
   WebFont.load({
     custom: {
-      families: ['Archia:n4,n7', 'Campton:n7', 'Space Mono:n4,n7'],
-      urls: ['https://adoring-einstein-015923.netlify.com/assets/css/fonts.css']
+      families: allFonts,
+      urls: [styleSheetUrl]
     },
     active,
+    fontactive,
     ...opts
   })
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "loose-envify": "^1.4.0",
     "postcss": "^7.0.11",
     "postcss-import": "^12.0.1",
-    "stream-template": "0.0.10"
+    "stream-template": "0.0.10",
+    "webfontloader": "^1.6.28"
   }
 }

--- a/spinner/style.css
+++ b/spinner/style.css
@@ -6,8 +6,8 @@ html {
 
 ._loading_spinner_:before,
 ._loading_spinner_:after,
-body:not(.content-ready):before,
-body:not(.content-ready):after {
+body:not(.content-ready):not(.has-no-spinner):before,
+body:not(.content-ready):not(.has-no-spinner):after {
   width: 124px;
   height: 120px;
   position: absolute;
@@ -17,8 +17,8 @@ body:not(.content-ready):after {
   z-index: 9;
 }
 
-body:not(.content-ready):before,
-body:not(.content-ready):after {
+body:not(.content-ready):not(.has-no-spinner):before,
+body:not(.content-ready):not(.has-no-spinner):after {
   top: 50vh;
   left: 50vw;
 }
@@ -32,13 +32,13 @@ body:not(.content-ready):after {
   filter: blur(3px);
 }
 
-body:not(.content-ready) {
+body:not(.content-ready):not(.has-no-spinner) {
   position: relative;
   z-index: 3;
 }
 
 ._loading_spinner_:before,
-body:not(.content-ready):before{
+body:not(.content-ready):not(.has-no-spinner):before{
   animation: loading 1.6s infinite linear;
   border-bottom: 4px solid var(--spinner-border-color);
   border-left: 1px solid var(--spinner-base-border-color);
@@ -53,10 +53,11 @@ body:not(.content-ready):before{
 }
 
 ._loading_spinner_:after,
-body:not(.content-ready):after{
+body:not(.content-ready):not(.has-no-spinner):after{
   color: var(--max-contrast);
   content: var(--loading-message);
   display: flex;
+  font-family: sans-serif;
   font-size: 12px;
   font-weight: bold;
   height: auto;
@@ -74,5 +75,5 @@ body:not(.content-ready):after{
     -ms-transform: rotate(359deg);
     -o-transform: rotate(359deg);
     transform: rotate(359deg);
-  } 
+  }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -5,6 +5,32 @@ html {
   --nc-colour-tray-backdrop: rgba(0, 0, 0, 0.6);
   --nc-colour-tray: #292d39;
   --nc-colour-header-background: #292d39;
+  --nc-font-family-sans: Archia, sans-serif;
+  --nc-font-family-sans-alt: Campton, sans-serif;
+  --nc-font-family-monospace: 'Space Mono', monospace;
+}
+
+html {
+  font-family: var(--nc-font-family-sans);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--nc-font-family-sans-alt);
+}
+
+pre,
+code {
+  font-family: var(--nc-font-family-monospace);
+}
+
+input,
+button {
+  font-family: inherit;
 }
 
 /* Icon */

--- a/templates/main.js
+++ b/templates/main.js
@@ -15,7 +15,7 @@ const main = (opts = {}) => streamTemplate`
       <style>${opts.styles}</style>
       ${opts.head}
     </head>
-    <body>
+    <body class="${opts.bodyClass}">
       ${header(opts)}
       ${opts.body}
       ${askTray(opts)}


### PR DESCRIPTION
PRs into Doctor, Bubbleprof and Flame are on their way with diffs to show before/after font usage.

## Overview
Creates a `fontLoader` behaviour to allow tools to load remote fonts like so:

```js
loadFonts({
  onLoad() => renderUiWithFonts(),
  onTimeout() => renderUiWithoutFonts() // Will incur FOUT
})
```

Adds font defaults to base styles for easy inheritance across tools.

Updates spinner to avoid allow tool not to show spinner in body on initial load. This is to avoid spinner duplication when loading fonts and showing spinner for that.