### PR TITLE
Override webkit/moz-OSX smoothing for light-on-dark text

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -226,7 +226,7 @@ html {
 
 /* Modifiers */
 
-.nc--light-on-dark,
+.nc-light-on-dark,
 html.light-theme main .nc--dark-on-light  {
   /* Light text on a dark background may look blocky without this, esp. on MacOS
    * Only for use on light text on a dark background, see:
@@ -237,7 +237,7 @@ html.light-theme main .nc--dark-on-light  {
 }
 
 .nc--dark-on-light,
-html.light-theme main .nc--light-on-dark {
+html.light-theme main .nc-light-on-dark {
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -224,6 +224,24 @@ html {
   align-items: center;
 }
 
+/* Modifiers */
+
+.nc--light-on-dark,
+html.light-theme main .nc--dark-on-light  {
+  /* Light text on a dark background may look blocky without this, esp. on MacOS
+   * Only for use on light text on a dark background, see:
+   * http://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/
+   */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.nc--dark-on-light,
+html.light-theme main .nc--light-on-dark {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+}
+
 @media(min-width: 640px) {
   .nc-button {
     padding: 0.5em 1em;

--- a/templates/ask-tray.js
+++ b/templates/ask-tray.js
@@ -5,7 +5,7 @@ const close = require('../icons/close')
 
 const askTray = opts => streamTemplate`
   <div class="nc-tray-backdrop" data-nc-ask-tray-backdrop></div>
-  <div class="nc-tray nc--light-on-dark">
+  <div class="nc-tray nc-light-on-dark">
     <div class="nc-tray__inner">
       <h3>Ask an expert</h3>
       <p>You can get to an expert by running this command:</p>

--- a/templates/ask-tray.js
+++ b/templates/ask-tray.js
@@ -5,7 +5,7 @@ const close = require('../icons/close')
 
 const askTray = opts => streamTemplate`
   <div class="nc-tray-backdrop" data-nc-ask-tray-backdrop></div>
-  <div class="nc-tray">
+  <div class="nc-tray nc--light-on-dark">
     <div class="nc-tray__inner">
       <h3>Ask an expert</h3>
       <p>You can get to an expert by running this command:</p>


### PR DESCRIPTION
This:

- Adds a class that can be applied to light-on-dark text so that it renders more smoothly on OSX. Tested on Sierra (10.12.6), if someone could confirm it's still the same on a more recent version, that'd be great (from what I can tell, it is)
- Adds an optional class to reverse it for child elements
- Flips the classes' behaviour inside <main> on light theme
- Applies that class to the Ask tray

Before: (system font left, brand font right)

![image](https://user-images.githubusercontent.com/29628323/51925203-74c49000-23e6-11e9-8c0f-86f3d08d68ef.png)

After:

![image](https://user-images.githubusercontent.com/29628323/51925357-c66d1a80-23e6-11e9-9abb-9c739b3e940b.png)



