### PR TITLE
Allow passing a separate data file into the main template

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ const scriptFile = buildJs({
 
 💡 The `debug` option will ensure the bundle contains a sourcemap
 
+💡 If `fakeDataPath` is not provided, make sure to provide a separate `dataFile` to the [main template](#templates).
+
 ### `buildCss(opts = {})`
 Returns a PostCSS bundle (Promise)
 
@@ -109,7 +111,7 @@ const styleFile = buildCss({
 ***
 
 ## Templates
-Templates use stream-templates to interpolate streams, promises and strings into a common template without the need to buffer them first.
+Templates use [`stream-template`](https://github.com/almost/stream-template) to interpolate streams, promises and strings into a common template without the need to buffer them first.
 
 ### `mainTemplate(opts = {})`
 Returns a streamTemplate (Readable Stream)
@@ -127,6 +129,7 @@ const outputFile = mainTemplate({
   favicon: 'URI', (String)
   title: 'Title', (String)
   styles: styleFile, (Readable Stream)
+  data: dataFile, (Readable Stream)
   script: scriptFile, (Promise)
   headerLogoUrl: 'https://github.com/somewhere', (String)
   headerLogoTitle: 'Logo title', (String)
@@ -138,6 +141,8 @@ const outputFile = mainTemplate({
   body: 'extra <body> contents' (String)
 })
 ```
+
+💡 `opts.data` can be provided to place the JSON output of the analysis into its own script tag. When not provided, analysis data should be bundled in the `scriptFile` by the user.
 
 ***
 

--- a/templates/main.js
+++ b/templates/main.js
@@ -19,6 +19,9 @@ const main = (opts = {}) => streamTemplate`
       ${header(opts)}
       ${opts.body}
       ${askTray(opts)}
+      ${opts.data ? streamTemplate`
+        <script type="application/json" id="clinic-data">${opts.data}</script>
+      ` : ''}
       <script>${opts.script}</script>
     </body>
   </html>


### PR DESCRIPTION
The JSON data will be placed in a separate `<script type="application/json">`, and the Clinic.js visualizers can parse the data from there.
The main motivation is that the massive JSON blobs that are embedded in the visualizer JS can make it hard to navigate, especially if there are minifier bugs like in https://github.com/nearform/node-clinic/issues/226. That one caused vim to hang for a while because there was 40MB of JSON on the line I was looking at :)

This would be good for runtime performance reasons, too, because the
browser can parse the sometimes 10s of megabytes of data as JSON instead
of as JS, which is much faster.

This would also allow us to avoid re-bundling the visualizer on every
profile later. We could instead bundle it once when we publish
Clinic.js packages. Bundling is not the biggest timesink but if we can
avoid that work it will still help a little.