### PR TITLE
Remove Nearform logo to improve aesthetic and minimalist design

### DIFF
--- a/templates/header.js
+++ b/templates/header.js
@@ -16,15 +16,6 @@ const header = (opts = {}) => streamTemplate`
       <span class="nc-header__logo-text">${opts.headerText}</span>
     </a>
     <div class="nc-header__inner">
-      <a
-        class="nc-header__sponsor"
-        href="https://nearform.com"
-        title="NearForm"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        ${opts.nearFormLogo}
-      </a>
       <button class="nc-ask-button" data-nc-ask-button>
         <span class="nc-icon nc-ask-button__icon">
           ${speechBubble}


### PR DESCRIPTION
Issue:
"Eyes are drawn to the NearForm logo although it is a secondary element in terms of hierarchy."

Fix:
Step 1 - removing the logo from the header.

![image](https://user-images.githubusercontent.com/4488048/80799806-be7ac800-8b9f-11ea-94ca-20a293bdcfe6.png)

Another PR will be required to move the logo to the bottom left corner. After we merge:
https://github.com/nearform/node-clinic-flame/pull/115
