### PR TITLE
Hide "previous step" arrow on content walkthrough when on step 0

### DIFF
--- a/base/walkthrough-player.js
+++ b/base/walkthrough-player.js
@@ -38,6 +38,7 @@ class WalkthroughPlayer {
       this.controls.classList.add('nc-walkthrough-controls')
 
       this.prevBtn = button({
+        classNames: ['prevBtn'],
         leftIcon: chevronLeft,
         onClick: e => this.prev()
       })
@@ -120,6 +121,14 @@ class WalkthroughPlayer {
 
     this.wrapper.classList.toggle('done', isDone)
     this.prevBtn.disabled = this.currentStepIndex === 0
+    
+    if (this.currentStepIndex === 0) {
+      const btn = this.controls.getElementsByClassName('prevBtn')[0]
+      btn.style.visibility = 'hidden'
+    } else {
+      const btn = this.controls.getElementsByClassName('prevBtn')[0]
+      btn.style.visibility = 'visible'
+    }
 
     if (this.showControls) {
       this.prev.setAttribute('disabled', this.currentStepIndex <= 0 ? true : null)

--- a/base/walkthrough-player.js
+++ b/base/walkthrough-player.js
@@ -123,11 +123,7 @@ class WalkthroughPlayer {
     this.prevBtn.disabled = this.currentStepIndex === 0
     
     if (this.currentStepIndex === 0) {
-      const btn = this.controls.getElementsByClassName('prevBtn')[0]
-      btn.style.visibility = 'hidden'
-    } else {
-      const btn = this.controls.getElementsByClassName('prevBtn')[0]
-      btn.style.visibility = 'visible'
+      this.prevBtn.style.visible = 'hidden'
     }
 
     if (this.showControls) {
@@ -148,7 +144,11 @@ class WalkthroughPlayer {
     setTimeout(() => {
       this.content.innerHTML = ''
       this.content.appendChild(helpers.toHtml(step.msg))
-
+      if (this.currentStepIndex === 0) {
+        this.prevBtn.style.visibility = 'hidden'
+      } else {
+        this.prevBtn.style.visibility = 'visible'
+      }
       WtOverlay.updateContent({
         msg: this.wrapper,
         classNames: ['wt-container', 'zoom-in', `wt-step-${this.currentStepIndex}`]

--- a/base/walkthrough-player.js
+++ b/base/walkthrough-player.js
@@ -142,7 +142,7 @@ class WalkthroughPlayer {
     setTimeout(() => {
       this.content.innerHTML = ''
       this.content.appendChild(helpers.toHtml(step.msg))
-  this.prevBtn.style.visibility = this.currentStepIndex === 0 ? 'hidden' : 'visible'
+      this.prevBtn.style.visibility = this.currentStepIndex === 0 ? 'hidden' : 'visible'
 
       WtOverlay.updateContent({
         msg: this.wrapper,

--- a/base/walkthrough-player.js
+++ b/base/walkthrough-player.js
@@ -119,7 +119,7 @@ class WalkthroughPlayer {
     const isDone = this.currentStepIndex === this.steps.length - 1
 
     this.wrapper.classList.toggle('done', isDone)
-    
+
     if (this.currentStepIndex === 0) {
       this.prevBtn.style.visible = 'hidden'
     }

--- a/base/walkthrough-player.js
+++ b/base/walkthrough-player.js
@@ -119,7 +119,6 @@ class WalkthroughPlayer {
     const isDone = this.currentStepIndex === this.steps.length - 1
 
     this.wrapper.classList.toggle('done', isDone)
-    this.prevBtn.disabled = this.currentStepIndex === 0
     
     if (this.currentStepIndex === 0) {
       this.prevBtn.style.visible = 'hidden'

--- a/base/walkthrough-player.js
+++ b/base/walkthrough-player.js
@@ -142,11 +142,8 @@ class WalkthroughPlayer {
     setTimeout(() => {
       this.content.innerHTML = ''
       this.content.appendChild(helpers.toHtml(step.msg))
-      if (this.currentStepIndex === 0) {
-        this.prevBtn.style.visibility = 'hidden'
-      } else {
-        this.prevBtn.style.visibility = 'visible'
-      }
+  this.prevBtn.style.visibility = this.currentStepIndex === 0 ? 'hidden' : 'visible'
+
       WtOverlay.updateContent({
         msg: this.wrapper,
         classNames: ['wt-container', 'zoom-in', `wt-step-${this.currentStepIndex}`]

--- a/base/walkthrough-player.js
+++ b/base/walkthrough-player.js
@@ -38,7 +38,6 @@ class WalkthroughPlayer {
       this.controls.classList.add('nc-walkthrough-controls')
 
       this.prevBtn = button({
-        classNames: ['prevBtn'],
         leftIcon: chevronLeft,
         onClick: e => this.prev()
       })


### PR DESCRIPTION
[Issue FL01](https://trello.com/c/UOqMVZx9/845-fl01-user-control-and-freedom)