### PR TITLE
Bumping version to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/clinic-common",
-  "version": "3.1.0",
+  "version": "3.2.1",
   "description": "Shared parts between the Clinic.js suite",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
The package.json version was not properly bumped to 3.2.0 when
the v3.2.0 tag was pushed. Bump to 3.2.1 and retagging.